### PR TITLE
build: Deprecate package set

### DIFF
--- a/build/checks/build-systems.nix
+++ b/build/checks/build-systems.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  pyproject-nix,
+}:
+let
+  overlay' =
+    final: _prev:
+    lib.mapAttrs
+      (
+        name: pkg:
+        if pyproject-nix.build.lib.isBootstrapPackage name then
+          final.callPackage pkg { pyprojectHook = final.pyprojectBootstrapHook; }
+        else
+          final.callPackage pkg { }
+      )
+      {
+        flit-core = ../pkgs/flit-core;
+        packaging = ../pkgs/packaging;
+        pyproject-hooks = ../pkgs/pyproject-hooks;
+        setuptools = ../pkgs/setuptools;
+        wheel = ../pkgs/wheel;
+        hatchling = ../pkgs/hatchling;
+        pdm-backend = ../pkgs/pdm-backend;
+        cython = ../pkgs/cython;
+        meson = ../pkgs/meson;
+        build = ../pkgs/build;
+        installer = ../pkgs/installer;
+        pathspec = ../pkgs/pathspec;
+        pluggy = ../pkgs/pluggy;
+        setuptools-scm = ../pkgs/setuptools-scm;
+        trove-classifiers = ../pkgs/trove-classifiers;
+        calver = ../pkgs/calver;
+        zipp = ../pkgs/zipp;
+        tomli-w = ../pkgs/tomli-w;
+        cffi = ../pkgs/cffi;
+        maturin = ../pkgs/maturin;
+        setuptools-rust = ../pkgs/setuptools-rust;
+        pycparser = ../pkgs/pycparser;
+        typing-extensions = ../pkgs/typing-extensions;
+        semantic-version = ../pkgs/semantic-version;
+        tomli = ../pkgs/tomli;
+        pip = ../pkgs/pip;
+      };
+
+  crossOverlay = lib.composeExtensions (_final: prev: {
+    pythonPkgsBuildHost = prev.pythonPkgsBuildHost.overrideScope overlay';
+  }) overlay';
+
+in
+final: prev:
+if prev.stdenv.buildPlatform != prev.stdenv.hostPlatform then
+  crossOverlay final prev
+else
+  overlay' final prev

--- a/build/checks/default.nix
+++ b/build/checks/default.nix
@@ -10,10 +10,16 @@ let
 
   python = pkgs.python312;
 
-  # Inject your own packages on top with overrideScope
-  pythonSet = pkgs.callPackage pyproject-nix.build.packages {
-    inherit python;
+  buildSystems = import ./build-systems.nix {
+    inherit pyproject-nix lib;
   };
+
+  # Inject your own packages on top with overrideScope
+  pythonSet =
+    (pkgs.callPackage pyproject-nix.build.packages {
+      inherit python;
+    }).overrideScope
+      buildSystems;
 
   testVenv = pythonSet.pythonPkgsHostHost.mkVirtualEnv "test-venv" {
     build = [ ];
@@ -43,9 +49,11 @@ in
     let
       pkgs' = pkgs.pkgsCross.aarch64-multiplatform;
       python = pkgs'.python312;
-      crossSet = pkgs'.callPackage pyproject-nix.build.packages {
-        inherit python;
-      };
+      crossSet =
+        (pkgs'.callPackage pyproject-nix.build.packages {
+          inherit python;
+        }).overrideScope
+          buildSystems;
     in
     crossSet.pythonPkgsHostHost.mkVirtualEnv "cross-venv" {
       build = [ ];

--- a/build/hacks/checks.nix
+++ b/build/hacks/checks.nix
@@ -7,9 +7,15 @@ let
 
   python = pkgs.python3;
 
-  pythonSet = pkgs.callPackage pyproject-nix.build.packages {
-    inherit python;
+  buildSystems = import ../checks/build-systems.nix {
+    inherit pyproject-nix lib;
   };
+
+  pythonSet =
+    (pkgs.callPackage pyproject-nix.build.packages {
+      inherit python;
+    }).overrideScope
+      buildSystems;
 
 in
 {

--- a/build/lib/test_renderers.nix
+++ b/build/lib/test_renderers.nix
@@ -12,7 +12,13 @@ let
 
   python = pkgs.python312;
 
-  pythonSet = pkgs.callPackage pyproject-nix.build.packages { inherit python; };
+  buildSystems = import ../checks/build-systems.nix {
+    inherit pyproject-nix lib;
+  };
+
+  pythonSet =
+    (pkgs.callPackage pyproject-nix.build.packages { inherit python; }).overrideScope
+      buildSystems;
 
 in
 

--- a/build/packages.nix
+++ b/build/packages.nix
@@ -1,7 +1,7 @@
 {
   lib,
-  pyproject-nix,
   resolvers,
+  pyproject-nix,
 }:
 let
   inherit (resolvers) resolveCyclic resolveNonCyclic;
@@ -31,7 +31,17 @@ let
 
   mkResolveVirtualEnv = set: spec: map (name: set.${name}) (resolveCyclic set spec);
 
-  pkgsFun = final: mkPkgs' { inherit (final) callPackage pyprojectBootstrapHook; };
+  deprecatedBuild = name: ''
+    You are using '${name}' from the pyproject.nix base package set, which is deprecated and will be removed shortly.
+
+    Build-system packages have been moved into their own repository which can be found at
+    https://github.com/pyproject-nix/build-system-pkgs
+  '';
+  pkgsFun =
+    final:
+    lib.mapAttrs (name: drv: builtins.trace (deprecatedBuild name) drv) (mkPkgs' {
+      inherit (final) callPackage pyprojectBootstrapHook;
+    });
 
   mkPythonSet =
     {


### PR DESCRIPTION
Pyproject.nix's package set is being removed in favour of using https://github.com/pyproject-nix/build-system-pkgs which is automated.