### PR TITLE
pyprojectInstallHook: Use uv's byte code compilation instead of custom hook

### DIFF
--- a/build/hooks/default.nix
+++ b/build/hooks/default.nix
@@ -203,6 +203,7 @@ in
           pyprojectBytecodeHook,
           pyprojectOutputSetupHook,
           python,
+          stdenv,
         }:
         makeSetupHook {
           name = "pyproject-hook";
@@ -212,9 +213,8 @@ in
             pyprojectConfigureHook
             pyprojectBuildHook
             pyprojectInstallHook
-            pyprojectBytecodeHook
             pyprojectOutputSetupHook
-          ];
+          ] ++ lib.optional (stdenv.buildPlatform != stdenv.hostPlatform) pyprojectBytecodeHook;
         } ./meta-hook.sh
       )
       (

--- a/build/hooks/pyproject-install-hook.sh
+++ b/build/hooks/pyproject-install-hook.sh
@@ -7,6 +7,10 @@ pyprojectInstallPhase() {
 
   pushd dist >/dev/null
 
+  if [ -z "${UV_COMPILE_BYTECODE-}" ]; then
+     export UV_COMPILE_BYTECODE=1
+  fi
+
   for wheel in ./*.whl; do
     @uv@/bin/uv pip --offline --no-cache install --no-deps --link-mode=copy --python=@pythonInterpreter@ --system --prefix "$out" $uvPipInstallFlags "$wheel"
     echo "Successfully installed $wheel"


### PR DESCRIPTION
And only use custom hook for cross where we can't yet use uv.