### PR TITLE
fix: better collision error message (copy/pastable filenames)

### DIFF
--- a/build/hooks/make-venv/make_venv.py
+++ b/build/hooks/make-venv/make_venv.py
@@ -43,7 +43,7 @@ class FileCollisionError(Exception):
     def __init__(self, inputs: list[Path]):
         err = f"""Two or more packages are trying to provide the same file with different contents
 
-        Files: {inputs}"""
+        Files: {' '.join((str(x) for x in inputs))}"""
         super().__init__(err)
 
 


### PR DESCRIPTION
Tiny quality of life improvement. Had a package where there where 8 __init__.py files colliding, and this way you can copy/paste the filenames for a quick md5sum.

Now looks like
```
       > __main__.FileCollisionError: Two or more packages are trying to provide the same file with different contents
       >
       >         Files: /nix/store/6qcjwvh8kx5bc10sbqkvsndjlqi3j2sw-azureml-core-1.57.0.post3/lib/python3.9/site-packages/azureml/__init__.py /nix/store/3dk98flclhm6fhpvz31bpsqrc4is7shz-azureml-train-automl-client-1.57.0/lib/python3.9/site-packages/azureml/__init__.py /nix/store/vvv01nh1v1s93z596pdwfhwsx7s1khrv-azureml-train-core-1.57.0/lib/python3.9/site-packages/azureml/__init__.py /nix/store/pnf0vb2a2gdsplsn77l8agqzz6mbki47-azureml-pipeline-core-1.57.0/lib/python3.9/site-packages/azureml/__init__.py /nix/store/46qn2zzp4crx0vk9plhz7r1sf0lrwg0l-azureml-pipeline-steps-1.57.0/lib/python3.9/site-packages/azureml/__init__.py /nix/store/nkvfibwdm3jdbm3f5gd4wgjplsn3d2qi-azureml-automl-core-1.57.0/lib/python3.9/site-packages/azureml/__init__.py /nix/store/mp1sxs07hr2i7knxc80lab5v4hka72wa-azureml-telemetry-1.57.0/lib/python3.9/site-packages/azureml/__init__.py /nix/store/4v6cjl5a32s5v8gcw50cwmsm7arwgx60-azureml-train-restclients-hyperdrive-1.57.0/lib/python3.9/site-packages/azureml/__init__.py
```

used to look like
```
> __main__.FileCollisionError: Two or more packages are trying to provide the same file with different contents
       >
       >         Files: [PosixPath('/nix/store/6qcjwvh8kx5bc10sbqkvsndjlqi3j2sw-azureml-core-1.57.0.post3/lib/python3.9/site-packages/azureml/__init__.py'), PosixPath('/nix/store/3dk98flclhm6fhpvz31bpsqrc4is7shz-azureml-train-automl-client-1.57.0/lib/python3.9/site-packages/azureml/__init__.py'), PosixPath('/nix/store/vvv01nh1v1s93z596pdwfhwsx7s1khrv-azureml-train-core-1.57.0/lib/python3.9/site-packages/azureml/__init__.py'), PosixPath('/nix/store/pnf0vb2a2gdsplsn77l8agqzz6mbki47-azureml-pipeline-core-1.57.0/lib/python3.9/site-packages/azureml/__init__.py'), PosixPath('/nix/store/46qn2zzp4crx0vk9plhz7r1sf0lrwg0l-azureml-pipeline-steps-1.57.0/lib/python3.9/site-packages/azureml/__init__.py'), PosixPath('/nix/store/nkvfibwdm3jdbm3f5gd4wgjplsn3d2qi-azureml-automl-core-1.57.0/lib/python3.9/site-packages/azureml/__init__.py'), PosixPath('/nix/store/mp1sxs07hr2i7knxc80lab5v4hka72wa-azureml-telemetry-1.57.0/lib/python3.9/site-packages/azureml/__init__.py'), PosixPath('/nix/store/4v6cjl5a32s5v8gcw50cwmsm7arwgx60-azureml-train-restclients-hyperdrive-1.57.0/lib/python3.9/site-packages/azureml/__init__.py')
```