### PR TITLE
build: Remove experimental label

### DIFF
--- a/build/lib/renderers.nix
+++ b/build/lib/renderers.nix
@@ -79,6 +79,8 @@ in
 
     Evaluates PEP-508 environment markers to select correct dependencies for the platform but does not validate version constraints.
 
+    Note: This API is unstable and subject to change.
+
     Type: mkDerivation :: AttrSet -> AttrSet
   */
   mkDerivationEditable =

--- a/doc/src/build.md
+++ b/doc/src/build.md
@@ -1,8 +1,7 @@
 # Build
 
 <div class="warning">
-The pyproject.nix build infrastructure is brand new and experimental.
-At this time it's mainly targeted at python2nix authors, and is being tested in uv2nix.
+The pyproject.nix build infrastructure is mainly targeted at python2nix authors, and is being used in uv2nix.
 </div>
 
 Pyproject.nix can be used with nixpkgs `buildPythonPackage`/`packageOverrides`/`withPackages`, but also implements it's own build infrastructure that fixes many structural problems with the nixpkgs implementation.

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,6 @@
           };
       };
 
-      # Note: This build infrastructure is experimental.
       build = import ./build {
         pyproject-nix = self;
         inherit lib;


### PR DESCRIPTION
Uv builds being binary reproducible was the last blocker, and uv 0.5.7 which contains support for disabling non-reproducible metadata has now reached nixos-unstable-small.

`mkDerivationEditable` is still marked as unstable because I'm not sure about the final api.