### PR TITLE
build: allow direct references in metadata

### DIFF
--- a/build/lib/renderers.nix
+++ b/build/lib/renderers.nix
@@ -152,6 +152,9 @@ in
               inherit (project') entry-points;
             };
 
+          # Allow direct references in dependencies and other metadata
+          tool.hatch.metadata.allow-direct-references = true;
+
           # Allow empty package
           tool.hatch.build.targets.wheel.bypass-selection = true;
 


### PR DESCRIPTION
As those are useful to refer to local packages relative to the root of a bigger repository. i.e.

```
optional-dependencies.foo = [
    "foo @ file:///{root:uri}/sub/dir/foo",
]
```