### PR TITLE
build.lib.renderers: Improve dynamic metadata support

### DIFF
--- a/build/lib/renderers.nix
+++ b/build/lib/renderers.nix
@@ -133,8 +133,10 @@ in
           # PEP-621 project table
           project =
             {
-              # Both name and version are required.
-              inherit (project') name version;
+              inherit (project') name;
+            }
+            // optionalAttrs (project' ? version) {
+              inherit (project') version;
             }
             // optionalAttrs (project' ? dependencies) {
               inherit (project') dependencies;

--- a/build/lib/renderers.nix
+++ b/build/lib/renderers.nix
@@ -100,6 +100,8 @@ in
         else
           project.projectRoot
       ),
+      # Synthetic pyproject.toml project table overrides
+      projectOverrides ? { },
     }:
     assert isString root;
     assert assertMsg (!hasPrefix storeDir root) ''
@@ -152,7 +154,8 @@ in
             }
             // optionalAttrs (project' ? entry-points) {
               inherit (project') entry-points;
-            };
+            }
+            // projectOverrides;
 
           # Allow direct references in dependencies and other metadata
           tool.hatch.metadata.allow-direct-references = true;


### PR DESCRIPTION
By making it possible to override the synthetic `pyproject.toml`'s project table.

This makes it possible to manually pass fields such as version which may be dynamic.