### PR TITLE
doc: Fix typo

### DIFF
--- a/doc/src/HACKING.md
+++ b/doc/src/HACKING.md
@@ -1,6 +1,6 @@
 # Hacking
 
-This document outlines hacking on `pyproject.nix` itself, and lays out it's project structure.
+This document outlines hacking on `pyproject.nix` itself, and lays out its project structure.
 
 ## Getting started
 

--- a/doc/src/build.md
+++ b/doc/src/build.md
@@ -4,7 +4,7 @@
 The pyproject.nix build infrastructure is mainly targeted at python2nix authors, and is being used in uv2nix.
 </div>
 
-Pyproject.nix can be used with nixpkgs `buildPythonPackage`/`packageOverrides`/`withPackages`, but also implements it's own build infrastructure that fixes many structural problems with the nixpkgs implementation.
+Pyproject.nix can be used with nixpkgs `buildPythonPackage`/`packageOverrides`/`withPackages`, but also implements its own build infrastructure that fixes many structural problems with the nixpkgs implementation.
 
 ## Problems with nixpkgs Python builders
 

--- a/doc/src/builders/hacks.md
+++ b/doc/src/builders/hacks.md
@@ -47,7 +47,7 @@ hacks.nixpkgsPrebuilt {
 
 ## Building Cargo (Rust) packages from source
 
-Rust has it's own package manager, Cargo, that expects to be able to download dependencies at build-time.
+Rust has its own package manager, Cargo, that expects to be able to download dependencies at build-time.
 One way to deal with that is to use [rustPlatform.importCargoLock](https://nixos.org/manual/nixpkgs/stable/#vendoring-of-dependencies).
 
 This mechanism uses IFD (import-from-derivation) on non-local packages.

--- a/doc/src/builders/overriding.md
+++ b/doc/src/builders/overriding.md
@@ -57,7 +57,7 @@ This patches RPATH's of wheels with native libraries, but those must be present 
 
 - [PEP-517](https://peps.python.org/pep-0517/) build systems
 
-Uv, like most Python package managers, installs binary wheels by default, and it's solver doesn't take into account bootstrapping dependencies.
+Uv, like most Python package managers, installs binary wheels by default, and its solver doesn't take into account bootstrapping dependencies.
 When building from an sdist instead of a wheel build systems will need to be added.
 
 ## Fixups

--- a/doc/src/builders/packages.md
+++ b/doc/src/builders/packages.md
@@ -13,8 +13,8 @@ pkgs.callPackage pyproject-nix.build.packages {
 
 ## Build-system packages
 
-For package managers that lack the ability so solve build-system dependencies `pyproject.nix` maintains a [base package set](https://github.com/pyproject-nix/build-system-pkgs).
-This set is much smaller and more narrow in scope than nixpkgs, it's purpose is only to package [build-system](https://peps.python.org/pep-0518/) dependencies, which are missing from Python package manager lock files, so needs to be supplemented from elsewhere.
+For package managers that lack the ability to solve build-system dependencies `pyproject.nix` maintains a [base package set](https://github.com/pyproject-nix/build-system-pkgs).
+This set is much smaller and more narrow in scope than nixpkgs, its purpose is only to package [build-system](https://peps.python.org/pep-0518/) dependencies, which are missing from Python package manager lock files, so needs to be supplemented from elsewhere.
 
 ## Overriding scope
 

--- a/doc/src/nixpkgs-build.md
+++ b/doc/src/nixpkgs-build.md
@@ -1,3 +1,3 @@
 # Build infrastructures
 
-Pyproject.nix can be used with nixpkgs `buildPythonPackage`/`packageOverrides`/`withPackages`, but also implements it's [own build infrastructure](./build.md) that fixes many structural problems with the nixpkgs implementation.
+Pyproject.nix can be used with nixpkgs `buildPythonPackage`/`packageOverrides`/`withPackages`, but also implements its [own build infrastructure](./build.md) that fixes many structural problems with the nixpkgs implementation.


### PR DESCRIPTION
This corrects some typos in documentation, e.g., it's -> its; so -> to.