### PR TITLE
build: Rework editables for full PEP-660 support

### DIFF
--- a/build/checks/build-systems.nix
+++ b/build/checks/build-systems.nix
@@ -198,6 +198,30 @@ let
             };
         };
 
+      editables =
+        {
+          stdenv,
+          python3Packages,
+          pyprojectHook,
+          resolveBuildSystem,
+        }:
+        stdenv.mkDerivation {
+          inherit (python3Packages.editables)
+            pname
+            version
+            src
+            meta
+            ;
+
+          nativeBuildInputs =
+            [
+              pyprojectHook
+            ]
+            ++ resolveBuildSystem {
+              flit-core = [ ];
+            };
+        };
+
       hatchling =
         {
           stdenv,
@@ -221,6 +245,7 @@ let
               pathspec = [ ];
               pluggy = [ ];
               trove-classifiers = [ ];
+              editables = [ ];
             }
             // lib.optionalAttrs (python.pythonOlder "3.11") {
               tomli = [ ];
@@ -602,6 +627,65 @@ let
             ]
             ++ resolveBuildSystem {
               flit-core = [ ];
+            };
+        };
+
+      libcst =
+        {
+          stdenv,
+          python3Packages,
+          pyprojectHook,
+          resolveBuildSystem,
+          rustPlatform,
+          cargo,
+          rustc,
+        }:
+        stdenv.mkDerivation {
+          inherit (python3Packages.libcst)
+            name
+            pname
+            src
+            version
+            cargoDeps
+            cargoRoot
+            ;
+          passthru.dependencies = {
+            pyyaml = [ ];
+          };
+          nativeBuildInputs =
+            [
+              pyprojectHook
+              rustPlatform.cargoSetupHook
+              cargo
+              rustc
+            ]
+            ++ resolveBuildSystem {
+              setuptools = [ ];
+              setuptools-rust = [ ];
+            };
+        };
+
+      pyyaml =
+        {
+          stdenv,
+          python3Packages,
+          pyprojectHook,
+          resolveBuildSystem,
+        }:
+        stdenv.mkDerivation {
+          inherit (python3Packages.pyyaml)
+            pname
+            version
+            src
+            meta
+            ;
+
+          nativeBuildInputs =
+            [
+              pyprojectHook
+            ]
+            ++ resolveBuildSystem {
+              setuptools = [ ];
             };
         };
     };

--- a/build/checks/default.nix
+++ b/build/checks/default.nix
@@ -156,25 +156,21 @@ let
             final: _prev: {
               myapp = final.callPackage (
                 {
-                  python,
                   stdenv,
-                  pyprojectHook,
+                  pyprojectEditableHook,
                   resolveBuildSystem,
-                  pythonPkgsBuildHost,
                 }:
                 stdenv.mkDerivation (
                   renderers.mkDerivationEditable
                     {
                       project = myapp;
                       environ = testEnviron;
-                      root = "$NIX_BUILD_TOP/src";
+                      root = "$NIX_BUILD_TOP";
                     }
                     {
                       inherit
-                        python
-                        pyprojectHook
+                        pyprojectEditableHook
                         resolveBuildSystem
-                        pythonPkgsBuildHost
                         ;
                     }
                 )

--- a/build/hooks/editable_hook/default.nix
+++ b/build/hooks/editable_hook/default.nix
@@ -1,0 +1,33 @@
+{
+  runCommand,
+  lib,
+  python,
+  mkVirtualEnv,
+}:
+
+let
+  env =
+    mkVirtualEnv "editable-hook-env" {
+      libcst = [ ];
+      pyproject-hooks = [ ];
+    }
+    // lib.optionalAttrs (python.pythonOlder "3.11") {
+      tomli = [ ];
+    };
+
+in
+runCommand "editable-hook" { } ''
+  mkdir -p $out/bin
+
+  cat > $out/bin/build-editable << EOF
+  #!${env}/bin/python
+  EOF
+  cat ${./editable_hook/build_editable.py} >> $out/bin/build-editable
+
+  cat > $out/bin/patch-editable << EOF
+  #!${env}/bin/python
+  EOF
+  cat ${./editable_hook/patch_editable.py} >> $out/bin/patch-editable
+
+  chmod +x $out/bin/*
+''

--- a/build/hooks/editable_hook/editable_hook/build_editable.py
+++ b/build/hooks/editable_hook/editable_hook/build_editable.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib  # pyright: ignore[reportMissingImports]
+import pyproject_hooks
+
+
+def main():
+    build_dir = Path(os.getcwd())
+    dist = build_dir.joinpath("dist")
+
+    with open(build_dir.joinpath("pyproject.toml"), "rb") as pyproject_file:
+        pyproject: dict[str, Any] = tomllib.load(pyproject_file)  # pyright: ignore[reportUnknownMemberType,reportExplicitAny]
+
+    # Get build backend with fallback behaviour
+    # https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour
+    try:
+        build_backend: str = pyproject["build-system"]["build-backend"]
+    except KeyError:
+        build_backend = "setuptools.build_meta:__legacy__"
+
+    try:
+        dist.mkdir()
+    except FileExistsError:
+        pass
+
+    # Call editable build hooks using pyproject-hooks
+    hook_caller = pyproject_hooks.BuildBackendHookCaller(
+        source_dir=str(build_dir),
+        build_backend=build_backend,
+    )
+    hook_caller.build_editable(str(dist))
+
+
+if __name__ == "__main__":
+    main()

--- a/build/hooks/editable_hook/editable_hook/patch_editable.py
+++ b/build/hooks/editable_hook/editable_hook/patch_editable.py
@@ -1,0 +1,140 @@
+import os.path
+import re
+from dataclasses import dataclass
+from typing import Callable
+
+import libcst as cst
+from libcst import (
+    Arg,
+    Attribute,
+    Call,
+    CSTTransformer,
+    Dot,
+    LeftParen,
+    Name,
+    RightParen,
+    SimpleString,
+)
+
+
+@dataclass
+class PatchResult:
+    code: str
+    patched: bool
+
+
+def make_call(str_repr: str):
+    return Call(
+        func=Attribute(
+            Attribute(
+                value=Call(
+                    func=Name("__import__"),
+                    args=[Arg(SimpleString('"os"'))],
+                ),
+                attr=Name("path"),
+                dot=Dot(),
+            ),
+            Name("expandvars"),
+            Dot(),
+        ),
+        args=[Arg(SimpleString(str_repr))],
+        lpar=[LeftParen()],
+        rpar=[RightParen()],
+    )
+
+
+class RewriteStrings(CSTTransformer):
+    build_dir: str
+    replacement: str
+
+    # Indicate whether file was patched or not
+    patched: bool = False
+
+    def __init__(self, build_dir: str, replacement: str):
+        self.build_dir = build_dir
+        self.replacement = replacement
+        super().__init__()
+
+    def leave_SimpleString(self, original_node: SimpleString, updated_node: SimpleString):
+        if original_node.raw_value.startswith(self.build_dir):
+            m = re.match(r"[^'\"]*['\"]+", original_node.value)
+            if m:
+                self.patched = True
+                prefix = m.group(0)
+                return make_call(prefix + self.replacement + original_node.value[len(self.build_dir) + len(prefix) :])
+        return updated_node
+
+
+def patch_py(
+    build_dir: str,
+    replacement: str,
+    code: str,
+):
+    tree = cst.parse_module(code)
+
+    string_rewriter = RewriteStrings(build_dir, replacement)
+    tree = tree.visit(string_rewriter)
+
+    return PatchResult(tree.code, string_rewriter.patched)
+
+
+def patch_pth(
+    build_dir: str,
+    replacement: str,
+    code: str,
+):
+    lines: list[str] = []
+    patched = False
+
+    for line in code.splitlines():
+        # Python code line, use Python patcher
+        if line.startswith("import "):
+            tree = cst.parse_module(line)
+            string_rewriter = RewriteStrings(build_dir, replacement)
+            lines.append(tree.visit(string_rewriter).code)
+            if string_rewriter.patched:
+                patched = True
+        # Bare path, turn into Python line
+        elif line.startswith(build_dir):
+            lines.append(
+                f'import sys; import os.path; sys.path.append(os.path.expandvars(("{replacement}{line[len(build_dir):]}")))'
+            )
+            patched = True
+        else:
+            lines.append(line)
+
+    return PatchResult("\n".join(lines) + "\n", patched)
+
+
+def fixup(patcher: Callable[..., PatchResult], build_dir: str, replacement: str, path: str):
+    with open(path) as fp:
+        code = fp.read()
+
+    patched = patcher(build_dir, replacement, code)
+    if not patched.patched:
+        return
+
+    with open(path, "w") as fp:
+        code = fp.write(patched.code)
+
+
+def main():
+    build_dir = os.getcwd()
+    replacement = os.environ["EDITABLE_ROOT"]
+
+    out = os.environ["out"]
+
+    for root, _, files in os.walk(out):
+        for filename in files:
+            if filename.endswith(".py"):
+                patcher = patch_py
+            elif filename.endswith(".pth"):
+                patcher = patch_pth
+            else:
+                continue
+
+            fixup(patcher, build_dir, replacement, os.path.join(root, filename))
+
+
+if __name__ == "__main__":
+    main()

--- a/build/hooks/editable_hook/fixtures/input.pth
+++ b/build/hooks/editable_hook/fixtures/input.pth
@@ -1,0 +1,5 @@
+# Bare path added to sys.path
+/build_dir/build/cp312
+
+# Handled by the Python rewriter
+import foo; foo(r"/build_dir/build/cp312")

--- a/build/hooks/editable_hook/fixtures/input.py
+++ b/build/hooks/editable_hook/fixtures/input.py
@@ -1,0 +1,22 @@
+print(
+    '/build_dir/build/cp312',
+    "/build_dir/build/cp312",
+    '''/build_dir/build/cp312''',
+    """/build_dir/build/cp312""",
+    b'/build_dir/build/cp312',
+    b"/build_dir/build/cp312",
+    r'/build_dir/build/cp312',
+    r"/build_dir/build/cp312",
+    rB'''/build_dir/build/cp312''',
+)
+
+# Comment, not patched
+#     '/build_dir/build/cp312',
+
+
+def foo():
+    """Look ma, not patched"""
+
+    # This case is tricky to patch correctly, so we don't try
+    x = r"also /build_dir/build/cp312 not patched"
+    print(x)

--- a/build/hooks/editable_hook/fixtures/output.pth
+++ b/build/hooks/editable_hook/fixtures/output.pth
@@ -1,0 +1,5 @@
+# Bare path added to sys.path
+import sys; import os.path; sys.path.append(os.path.expandvars(("$REPO_ROOT/build/cp312"))
+
+# Handled by the Python rewriter
+import foo; foo((__import__("os").path.expandvars(r"$REPO_ROOT/build/cp312")))

--- a/build/hooks/editable_hook/fixtures/output.py
+++ b/build/hooks/editable_hook/fixtures/output.py
@@ -1,0 +1,22 @@
+print(
+    (__import__("os").path.expandvars('$REPO_ROOT/build/cp312')),
+    (__import__("os").path.expandvars("$REPO_ROOT/build/cp312")),
+    (__import__("os").path.expandvars('''$REPO_ROOT/build/cp312''')),
+    (__import__("os").path.expandvars("""$REPO_ROOT/build/cp312""")),
+    (__import__("os").path.expandvars(b'$REPO_ROOT/build/cp312')),
+    (__import__("os").path.expandvars(b"$REPO_ROOT/build/cp312")),
+    (__import__("os").path.expandvars(r'$REPO_ROOT/build/cp312')),
+    (__import__("os").path.expandvars(r"$REPO_ROOT/build/cp312")),
+    (__import__("os").path.expandvars(rB'''$REPO_ROOT/build/cp312''')),
+)
+
+# Comment, not patched
+#     '/build_dir/build/cp312',
+
+
+def foo():
+    """Look ma, not patched"""
+
+    # This case is tricky to patch correctly, so we don't try
+    x = r"also /build_dir/build/cp312 not patched"
+    print(x)

--- a/build/hooks/editable_hook/pyproject.toml
+++ b/build/hooks/editable_hook/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "editable-hook"
+version = "0.1.0"
+description = "Build & patch editable packages with Nix"
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+  "libcst",
+  "pyproject-hooks",
+  "tomli; python_version < \"3.11\"",
+]
+
+[project.scripts]
+build-editable = "build_editable:main"
+patch-editable = "patch_editable:main"
+
+[build-system]
+requires = ["flit-core"]
+build-backend = "flit_core.buildapi"

--- a/build/hooks/editable_hook/shell.nix
+++ b/build/hooks/editable_hook/shell.nix
@@ -1,0 +1,27 @@
+let
+  pkgs = import <nixpkgs> { };
+
+  python = pkgs.python3;
+
+  # Quick-n-dirty
+  pythonEnv =
+    (python.withPackages (ps: [
+      ps.libcst
+      ps.pyproject-hooks
+      ps.flit-core
+    ])).override
+      {
+        postBuild = ''
+          cat > $out/pyvenv.cfg <<EOF
+          home = ${python}/bin
+          include-system-site-packages = false
+          EOF
+        '';
+      };
+
+in
+pkgs.mkShell {
+  packages = [
+    pythonEnv
+  ];
+}

--- a/build/hooks/editable_hook/test_patch_editable.py
+++ b/build/hooks/editable_hook/test_patch_editable.py
@@ -1,0 +1,31 @@
+import unittest
+
+from editable_hook import patch_editable
+
+
+class TestPatchEditable(unittest.TestCase):
+    def test_py(self):
+        with open("./fixtures/input.py") as fp:
+            input = fp.read()
+
+        with open("./fixtures/output.py") as fp:
+            expected = fp.read()
+
+        patched = patch_editable.patch_py("/build_dir", "$REPO_ROOT", input)
+        self.assertTrue(patched.patched)
+        self.assertEqual(expected, patched.code)
+
+    def test_pth(self):
+        with open("./fixtures/input.pth") as fp:
+            input = fp.read()
+
+        with open("./fixtures/output.pth") as fp:
+            expected = fp.read()
+
+        patched = patch_editable.patch_pth("/build_dir", "$REPO_ROOT", input)
+        self.assertTrue(patched.patched)
+        self.assertEqual(expected, patched.code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build/hooks/pyproject-build-editable-hook.sh
+++ b/build/hooks/pyproject-build-editable-hook.sh
@@ -1,0 +1,18 @@
+# Setup hook to use for PEP-621/setuptools builds
+echo "Sourcing pyproject-build-hook"
+
+pyprojectBuildEditablePhase() {
+  echo "Executing pyprojectBuildEditablePhase"
+  runHook preBuild
+
+  echo "Creating a wheel..."
+  env PYTHONPATH="${NIX_PYPROJECT_PYTHONPATH}:${PYTHONPATH}" @editableHook@/bin/build-editable
+
+  runHook postBuild
+  echo "Finished executing pyprojectBuildEditablePhase"
+}
+
+if [ -z "${dontUsePyprojectBuildEditable-}" ] && [ -z "${buildPhase-}" ]; then
+  echo "Using pyprojectBuildEditablePhase"
+  buildPhase=pyprojectBuildEditablePhase
+fi

--- a/build/hooks/pyproject-fixup-editable-hook.sh
+++ b/build/hooks/pyproject-fixup-editable-hook.sh
@@ -1,0 +1,7 @@
+pyprojectFixupEditableHook() {
+  @editableHook@/bin/patch-editable
+}
+
+if [ -z "${dontUsePyprojectEditableFixup-}" ]; then
+  preFixupPhases+=" pyprojectFixupEditableHook"
+fi

--- a/build/lib/renderers.nix
+++ b/build/lib/renderers.nix
@@ -6,12 +6,12 @@ let
     mapAttrs
     concatMap
     groupBy
-    pathExists
     isString
     assertMsg
     hasPrefix
     optionalString
     inPureEvalMode
+    unique
     ;
   inherit (pyproject-nix.lib.renderers) meta;
   inherit (pyproject-nix.lib) pep621;
@@ -20,11 +20,6 @@ let
   # Make a dependency specification attrset from a list of dependencies
   mkSpec =
     dependencies: mapAttrs (_: concatMap (dep: dep.extras)) (groupBy (dep: dep.name) dependencies);
-
-  fallbackBuildSystems = map pyproject-nix.lib.pep508.parseString [
-    "setuptools"
-    "wheel"
-  ];
 
 in
 {
@@ -74,15 +69,15 @@ in
     }
     // optionalAttrs (project.projectRoot != null) { src = project.projectRoot; };
 
-  /*
-    Renders a project as an argument that can be passed to stdenv.mkDerivation.
+ /*
+   Renders a project as an argument that can be passed to stdenv.mkDerivation.
 
-    Evaluates PEP-508 environment markers to select correct dependencies for the platform but does not validate version constraints.
+   Evaluates PEP-508 environment markers to select correct dependencies for the platform but does not validate version constraints.
 
-    Note: This API is unstable and subject to change.
+   Note: This API is unstable and subject to change.
 
-    Type: mkDerivation :: AttrSet -> AttrSet
-  */
+   Type: mkDerivation :: AttrSet -> AttrSet
+ */
   mkDerivationEditable =
     {
       # Loaded pyproject.nix project
@@ -92,16 +87,7 @@ in
       # Extras to enable (markers only, `optional-dependencies` are not enabled by default)
       extras ? [ ],
       # Editable root directory as a string
-      root ? toString (
-        # Prefer src layout if available
-        if pathExists (project.projectRoot + "/src") then
-          (project.projectRoot + "/src")
-        # Otherwise assume project root is editable root
-        else
-          project.projectRoot
-      ),
-      # Synthetic pyproject.toml project table overrides
-      projectOverrides ? { },
+      root ? project.projectRoot,
     }:
     assert isString root;
     assert assertMsg (!hasPrefix storeDir root) ''
@@ -115,108 +101,39 @@ in
       Pass editable root either as a string pointing to an absolute path non-store path, or use environment variables for relative paths.
     '';
     let
+      inherit (project) pyproject;
+
       filteredDeps = pep621.filterDependenciesByEnviron environ extras project.dependencies;
+      depSpec = mkSpec filteredDeps.dependencies;
+      buildSpec = mkSpec filteredDeps.build-systems;
+
     in
+    { pyprojectEditableHook, resolveBuildSystem }:
     {
-      python,
-      pyprojectHook,
-      pythonPkgsBuildHost,
-      resolveBuildSystem,
-    }:
-    let
-      project' = project.pyproject.project;
-      pname = project'.name;
-
-      # Synthetic pyproject.toml
-      #
-      # We don't use the provided build-system to build an editable package, we use hatchling.
-      pyproject =
-        {
-          # PEP-621 project table
-          project =
-            {
-              inherit (project') name;
-            }
-            // optionalAttrs (project' ? version) {
-              inherit (project') version;
-            }
-            // optionalAttrs (project' ? dependencies) {
-              inherit (project') dependencies;
-            }
-            // optionalAttrs (project' ? optional-dependencies) {
-              inherit (project') optional-dependencies;
-            }
-            // optionalAttrs (project' ? scripts) {
-              inherit (project') scripts;
-            }
-            // optionalAttrs (project' ? gui-scripts) {
-              inherit (project') gui-scripts;
-            }
-            // optionalAttrs (project' ? entry-points) {
-              inherit (project') entry-points;
-            }
-            // projectOverrides;
-
-          # Allow direct references in dependencies and other metadata
-          tool.hatch.metadata.allow-direct-references = true;
-
-          # Allow empty package
-          tool.hatch.build.targets.wheel.bypass-selection = true;
-
-          # Include our editable pointer file in build
-          tool.hatch.build.targets.wheel.force-include."_${pname}.pth" = "_${pname}.pth";
-
-          # Build editable package using hatchling
-          build-system = {
-            requires = [ "hatchling" ];
-            build-backend = "hatchling.build";
-          };
-        }
-        // optionalAttrs (project.pyproject ? dependency-groups) {
-          # PEP-735 dependency groups
-          inherit (project.pyproject) dependency-groups;
-        };
-    in
-    {
-      inherit pname;
-
       passthru = {
-        dependencies = mkSpec (
-          filteredDeps.dependencies
-          ++ (
-            if (filteredDeps.build-systems != [ ]) then filteredDeps.build-systems else fallbackBuildSystems
-          )
-        );
+        # Merge runtime dependenies with build systems
+        dependencies =
+          depSpec
+          // mapAttrs (name: extras: unique ((depSpec.${name} or [ ]) ++ extras)) buildSpec;
         optional-dependencies = mapAttrs (_: mkSpec) filteredDeps.extras;
         dependency-groups = mapAttrs (_: mkSpec) filteredDeps.groups;
       };
 
-      # Convert created JSON format pyproject.toml into TOML and include a generated pth file
-      unpackPhase = ''
-        env PYTHONPATH=${pythonPkgsBuildHost.tomli-w}/${python.sitePackages} python -c "import json, tomli_w; print(tomli_w.dumps(json.load(open('$pyprojectContentsPath'))))" > pyproject.toml
-        echo 'import os.path, sys; sys.path.insert(0, os.path.expandvars("${root}"))' > _${pname}.pth
-      '';
+      env.EDITABLE_ROOT = root;
 
-      nativeBuildInputs =
-        [
-          pyprojectHook
-        ]
-        ++ resolveBuildSystem {
-          hatchling = [ ];
-        };
-
-      pyprojectContents = builtins.toJSON pyproject;
-      passAsFile = [ "pyprojectContents" ];
+      nativeBuildInputs = [
+        pyprojectEditableHook
+      ] ++ resolveBuildSystem buildSpec;
 
       meta = meta {
         inherit project;
       };
     }
-    // optionalAttrs (project' ? version) {
-      inherit (project') version;
+    // optionalAttrs (pyproject.project ? name) { pname = pyproject.project.name; }
+    // optionalAttrs (pyproject.project ? version) { inherit (pyproject.project) version; }
+    // optionalAttrs (!pyproject.project ? version && pyproject.project ? name) {
+      inherit (pyproject.project) name;
     }
-    // optionalAttrs (!project' ? version) {
-      name = pname;
-    };
+    // optionalAttrs (project.projectRoot != null) { src = project.projectRoot; };
 
 }

--- a/build/lib/test_renderers.nix
+++ b/build/lib/test_renderers.nix
@@ -60,6 +60,7 @@ in
           nativeBuildInputs = [
             null
             "hatchling"
+            "editables"
             "packaging"
             "pathspec"
             "pluggy"

--- a/build/packages.nix
+++ b/build/packages.nix
@@ -77,6 +77,9 @@ let
         pyprojectMakeVenvHook
         pyprojectHook
         pyprojectWheelHook
+        pyprojectBuildEditableHook
+        pyprojectFixupEditableHook
+        pyprojectEditableHook
         ;
     };
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ extend-select = [
 ]
 extend-ignore = ["B018", "B019"]
 src = ["src"]
-exclude = ["tests/fixtures"]
+exclude = ["**/fixtures"]
 target-version = "py37"
 
 [tool.ruff.mccabe]
@@ -22,3 +22,7 @@ reportUnusedCallResult = "none"
 reportUnknownMemberType = "warning"
 pythonVersion = "3.9"
 include = [ "build" ]
+exclude = [
+  # The editable hook has third party dependencies and makes bootstrapping awkward
+  "build/hooks/editable_hook"
+]

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -39,6 +39,9 @@ let
               "check"
               "--fix"
             ];
+            excludes = [
+              "build/hooks/editable_hook/fixtures/**"
+            ];
           };
 
           ruff-format = {
@@ -46,6 +49,9 @@ let
             includes = [
               "*.py"
               "*.pyi"
+            ];
+            excludes = [
+              "build/hooks/editable_hook/fixtures/**"
             ];
             options = [ "format" ];
           };


### PR DESCRIPTION
The previously used mechanism of synthezising a package using hatchling sort of works, and was enough to prove the concept of editables with Nix.

This changes `mkDerivationEditable` to use PEP-660 and should support pretty much everything.

The big complication in this development was the need for source level patching since editables are a pretty loose concept and are implemented differently by different build systems. Source patching uses https://github.com/Instagram/LibCST/. I'd like to rewrite this bit purely in Rust later.

So far I've successfully used this support with a few build systems, most notably meson.

For meson this requires manually calling `build_editable.py` to create the initial files. After that point dynamic recompilation "just works". This will be exposed as a separate package somehow, just not yet.