### PR TITLE
Copy the wheel instead of symlinking it in dist-hook

### DIFF
--- a/build/hooks/pyproject-wheel-dist-hook.sh
+++ b/build/hooks/pyproject-wheel-dist-hook.sh
@@ -7,7 +7,7 @@ pyprojectWheelDist() {
 
   echo "Creating dist..."
   mkdir -p dist
-  ln -s "$src" "dist/$(stripHash "$src")"
+  cp "$src" "dist/$(stripHash "$src")"
 
   runHook postBuild
   echo "Finished executing pyprojectWheelDist"


### PR DESCRIPTION
This solves the issue that Python isn't finding the wheel because of an unexpected name format: the name of wheels before this commit is (nix-store-hash)-(python-wheel-name)-(python-wheelversion)-....whl, and this comit changes it to (python-wheel-name)-....whl