### PR TITLE
build.hooks.make-venv: Replace symlink to Python interpreter with a binary wrapper

### DIFF
--- a/build/checks/default.nix
+++ b/build/checks/default.nix
@@ -87,6 +87,24 @@ let
             touch $out
           '';
 
+      symlinked-venv =
+        let
+          # Create a derivation with a symlink to interpreter.
+          # This would break the vanilla venv module.
+          sym = pkgs.runCommand "symlinked-venv" { } ''
+            mkdir -p $out/bin
+            ln -s ${testVenv}/bin/python $out/bin/python
+          '';
+        in
+        pkgs.runCommand "symlinked-venv-test"
+          {
+            nativeBuildInputs = [ sym ];
+          }
+          ''
+            python -c 'import packaging'
+            touch $out
+          '';
+
       prebuilt-wheel = pythonSet.pythonPkgsHostHost.callPackage (
         {
           stdenv,


### PR DESCRIPTION
The venv module creates a symlink to the Python interpreter, but this breaks the venv if you're using a symlink pointing to the virtualenv itself.

By replacing the Python interpreter symlink with a wrapper it can be properly linked to in another derivation.

cc @TyberiusPrime 