### PR TITLE
Translate arm64 to aarch64 for wheel names

### DIFF
--- a/lib/pypa.nix
+++ b/lib/pypa.nix
@@ -293,9 +293,11 @@ lib.fix (self: {
         let
           m = match "linux_(.+)" platformTag;
           arch = elemAt m 0;
+
+          linuxArch = if platform.linuxArch == "arm64" then "aarch64" else platform.linuxArch;
         in
         assert m != null;
-        platform.isLinux && arch == platform.linuxArch
+        platform.isLinux && arch == linuxArch
       )
     else
       throw "Unknown platform tag: '${platformTag}'";


### PR DESCRIPTION
Problem: On Linux-aarch64 machines the `platform.linuxArch` contains `arm64` which is not the wheel suffix that is commonly used for Linux-aarch64 filenames (e.g., https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/ does not list `arm64` as part of a platform tag for Linux).

Solution: This change swaps out `arm64` with `aarch64` to find compatible wheels.