### PR TITLE
build.hooks.pyprojectWheelDist use copy instead of softlink

### DIFF
--- a/build/hooks/pyproject-wheel-dist-hook.sh
+++ b/build/hooks/pyproject-wheel-dist-hook.sh
@@ -7,7 +7,7 @@ pyprojectWheelDist() {
 
   echo "Creating dist..."
   mkdir -p dist
-  ln -s "$src" "dist/$(stripHash "$src")"
+  cp "$src" "dist/$(stripHash "$src")"
 
   runHook postBuild
   echo "Finished executing pyprojectWheelDist"


### PR DESCRIPTION
The symbolic link name is not used with matchWheelFileName but instead $(basename $src) is used, which includes the store hash.