### PR TITLE
build.hooks: Add hook to install dist directory into output

### DIFF
--- a/build/checks/default.nix
+++ b/build/checks/default.nix
@@ -250,4 +250,34 @@ listToAttrs (
       cffi = [ ];
     };
 
+  install-dist =
+    let
+      python = pkgs.python3;
+
+      pythonSet =
+        (pkgs.callPackage pyproject-nix.build.packages {
+          inherit python;
+        }).overrideScope
+          buildSystems;
+    in
+    pythonSet.build.override {
+      pyprojectHook = pythonSet.pyprojectDistHook;
+    };
+
+  install-dist-cross =
+    let
+      pkgs' = pkgs.pkgsCross.aarch64-multiplatform;
+
+      python = pkgs.python3;
+
+      pythonSet =
+        (pkgs'.callPackage pyproject-nix.build.packages {
+          inherit python;
+        }).overrideScope
+          buildSystems;
+    in
+    pythonSet.build.override {
+      pyprojectHook = pythonSet.pyprojectDistHook;
+    };
+
 }

--- a/build/hooks/dist-hook/install-wheels.py
+++ b/build/hooks/dist-hook/install-wheels.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def main():
+    cwd = Path(os.getcwd())
+    dist = cwd.joinpath("dist")
+
+    out = Path(os.environ["out"])
+
+    check_dist: bool
+    try:
+        check_dist = not bool(os.environ["dontUsePyprojectInstallDistCheck"])
+    except KeyError:
+        check_dist = True
+
+    wheels: list[Path] = [dist_file for dist_file in dist.iterdir() if dist_file.name.endswith(".whl")]
+
+    # Verify that wheel is not containing store path
+    if check_dist:
+        for wheel in wheels:
+            p = subprocess.run(
+                [
+                    "@ugrep@",
+                    # quiet
+                    "-q",
+                    # zip
+                    "-z",
+                    "@store_dir@",
+                    wheel,
+                ]
+            )
+            if p.returncode == 0:
+                raise ValueError(f"""
+                Built whheel '{wheel.name}' contains a Nix store path reference.
+
+                Wheel not usable for distribution.
+                """)
+
+    # Copy wheels to output
+    out.mkdir()
+    for wheel in wheels:
+        shutil.copy(wheel, out.joinpath(wheel.name))
+
+
+if __name__ == "__main__":
+    main()

--- a/build/hooks/dist-hook/pyproject-install-dist-hook.sh
+++ b/build/hooks/dist-hook/pyproject-install-dist-hook.sh
@@ -1,0 +1,17 @@
+# Setup hook for installing built wheels into output
+echo "Sourcing pyproject-install-dist-hook"
+
+pyprojectInstallDistPhase() {
+  echo "Executing pyprojectInstallDistPhase"
+  runHook preInstall
+
+  @pythonInterpreter@ @script@
+
+  runHook postInstall
+  echo "Finished executing pyprojectInstallDistPhase"
+}
+
+if [ -z "${dontUsePyprojectInstallDist-}" ] && [ -z "${installPhase-}" ]; then
+  echo "Using pyprojectInstallDistPhase"
+  installPhase=pyprojectInstallDistPhase
+fi

--- a/build/packages.nix
+++ b/build/packages.nix
@@ -86,6 +86,9 @@ let
         pyprojectBuildEditableHook
         pyprojectFixupEditableHook
         pyprojectEditableHook
+        pyprojectInstallDistHook
+        pyprojectDistHook
+        pyprojectPypaInstallHook
         ;
     };
 


### PR DESCRIPTION
`pyprojectDistHook` is to be used instead of `pyprojectHook` when you want to get the wheel files instead of the installed files.