### PR TITLE
build.lib.query: init package set query API

### DIFF
--- a/build/lib/default.nix
+++ b/build/lib/default.nix
@@ -9,5 +9,6 @@ fix (
   mapAttrs (_: path: import path ({ inherit pyproject-nix lib; } // self)) {
     renderers = ./renderers.nix;
     resolvers = ./resolvers.nix;
+    query = ./query.nix;
   }
 )

--- a/build/lib/query.nix
+++ b/build/lib/query.nix
@@ -1,0 +1,67 @@
+{ lib, ... }:
+
+let
+  inherit (lib)
+    zipAttrsWith
+    concatLists
+    optional
+    attrNames
+    ;
+
+in
+{
+  /**
+    Query a package set for a dependency specification to pass to `mkVirtualEnv`.
+
+    Returns a specification with _only_ the dependencies of packages, not the queried packages themselves.
+
+    This is useful for example if you want to construct a virtualenv
+    with development dependencies for a package, but without containing the package itself.
+
+    # Example
+
+    ```nix
+    query.deps { } pythonSet {
+      hello-world = [ "dev" ];
+    }
+    =>
+    {
+      urllib3 = [ ]; # From project.dependencies
+      ruff = [ ]; # From the `dev` group
+    }
+    ```
+
+    # Arguments
+
+    customisations
+    : Query customisations (whether to include project.dependencies or not)
+
+    pythonSet
+    : Python package set
+
+    specification
+    : Dependency specifications in the form used by mkVirtualEnv
+  */
+  deps =
+    {
+      dependencies ? true,
+    }:
+    pythonSet: spec:
+    zipAttrsWith (_: concatLists) (
+      map (
+        name:
+        let
+          extras = spec.${name};
+          drv = pythonSet.${name};
+          optional-dependencies = drv.passthru.optional-dependencies or { };
+          dependency-groups = drv.passthru.dependency-groups or { };
+        in
+        zipAttrsWith (_: concatLists) (
+          optional dependencies (drv.passthru.dependencies or { })
+          ++ map (e: optional-dependencies.${e} or { }) extras
+          ++ map (e: dependency-groups.${e} or { }) extras
+        )
+      ) (attrNames spec)
+    );
+
+}

--- a/build/lib/test.nix
+++ b/build/lib/test.nix
@@ -6,4 +6,5 @@
 
 {
   renderers = import ./test_renderers.nix { inherit pkgs lib pyproject-nix; };
+  query = import ./test_query.nix { inherit pkgs lib pyproject-nix; };
 }

--- a/build/lib/test_query.nix
+++ b/build/lib/test_query.nix
@@ -1,0 +1,111 @@
+{
+  pyproject-nix,
+  ...
+}:
+
+let
+  inherit (pyproject-nix.build.lib.query) deps;
+
+  testpkg = {
+    passthru = {
+      dependencies = {
+        dep-a = [ "extra-foo" ];
+      };
+      optional-dependencies = {
+        extra-a = {
+          dep-b = [ "extra-bar" ];
+        };
+        extra-b = {
+          dep-b = [ "extra-baz" ];
+        };
+      };
+      dependency-groups = {
+        group-a = {
+          dep-c = [ "extra-bar" ];
+        };
+        group-b = {
+          dep-c = [ "extra-baz" ];
+        };
+      };
+    };
+  };
+
+  pythonSet = {
+    inherit testpkg;
+  };
+
+in
+
+{
+  deps = {
+    testTrivial = {
+      expr = deps { } pythonSet {
+        testpkg = [ ];
+      };
+      expected = {
+        dep-a = [ "extra-foo" ];
+      };
+    };
+
+    testNoDeps = {
+      expr = deps { dependencies = false; } testpkg {
+        testpkg = [ ];
+      };
+      expected = { };
+    };
+
+    testExtras = {
+      expr = deps { } pythonSet {
+        testpkg = [
+          "extra-a"
+          "extra-b"
+        ];
+      };
+      expected = {
+        dep-a = [ "extra-foo" ];
+        dep-b = [
+          "extra-bar"
+          "extra-baz"
+        ];
+      };
+    };
+
+    testGroups = {
+      expr = deps { } pythonSet {
+        testpkg = [
+          "group-a"
+          "group-b"
+        ];
+      };
+      expected = {
+        dep-a = [ "extra-foo" ];
+        dep-c = [
+          "extra-bar"
+          "extra-baz"
+        ];
+      };
+    };
+
+    testMixed = {
+      expr = deps { } pythonSet {
+        testpkg = [
+          "extra-a"
+          "extra-b"
+          "group-a"
+          "group-b"
+        ];
+      };
+      expected = {
+        dep-a = [ "extra-foo" ];
+        dep-b = [
+          "extra-bar"
+          "extra-baz"
+        ];
+        dep-c = [
+          "extra-bar"
+          "extra-baz"
+        ];
+      };
+    };
+  };
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -46,6 +46,7 @@
   - [lib](./build/lib/index.md)
     - [renderers](./build/lib/renderers.md)
     - [resolvers](./build/lib/resolvers.md)
+    - [query](./build/lib/query.md)
   - [packages](./build/packages.md)
     - [packages.hooks](./build/hooks.md)
   - [hacks](./build/hacks.md)

--- a/doc/src/build/lib/query.md
+++ b/doc/src/build/lib/query.md
@@ -1,0 +1,5 @@
+<div class="warning">
+The query API is still experimental and subject to change.
+</div>
+
+<!-- cmdrun nixdoc --prefix build.lib --category query --description build.lib.query --file ../../../../build/lib/query.nix -->


### PR DESCRIPTION
This API is useful if you want to create a virtualenv consisting of a packages dependencies, but without the package itself.

``` nix
pythonSet.mkVirtualEnv "hello-env" {
  hello-world = [ "dev" ];
}
```
will create a virtual environment with `hello-world` _and_ its development dependencies.

``` nix
pythonSet.mkVirtualEnv "hello-env" (query.deps { } pythonSet {
  hello-world = [ "dev" ];
}
```
will create a virtual environment with `hello-world`'s main dependencies & its development dependencies, but not `hello-world` itself.

``` nix
pythonSet.mkVirtualEnv "hello-env" (query.deps { dependencies = false; } pythonSet {
  hello-world = [ "dev" ];
}
```
will create a virtual environment with `hello-world`'s development dependencies _only_.