### PR TITLE
build.hooks: replace deprecated substituteAll with replaceVars

### DIFF
--- a/build/hooks/default.nix
+++ b/build/hooks/default.nix
@@ -7,7 +7,7 @@
   stdenv,
   hooks,
   runCommand,
-  substituteAll,
+  replaceVars,
 }:
 let
   inherit (python) pythonOnBuildForHost;
@@ -286,8 +286,7 @@ in
           name = "pyproject-install-dist-hook";
           substitutions = {
             inherit pythonInterpreter;
-            script = substituteAll {
-              src = ./dist-hook/install-dist.py;
+            script = replaceVars ./dist-hook/install-dist.py {
               ugrep = lib.getExe ugrep;
               store_dir = builtins.storeDir;
             };


### PR DESCRIPTION
```bash
evaluation warning: substituteAll is deprecated and will be removed in 25.11. Use replaceVars instead.
```

Related: https://github.com/NixOS/nixpkgs/pull/395275