### PR TITLE
pypa: platform doesn't hold is32Bit and isx86

### DIFF
--- a/lib/pypa.nix
+++ b/lib/pypa.nix
@@ -296,7 +296,7 @@ lib.fix (self: {
         )
       )
     else if platformTag == "win32" then
-      (platform.isWindows && platform.is32Bit && platform.isx86)
+      (platform.isWindows && platform.is32bit && platform.isx86_32)
     else if hasPrefix "win_" platformTag then
       (
         let


### PR DESCRIPTION
Instead, `platform` holds `is32bit` and `isx86_32`.