### PR TITLE
fix: use isiOS instead of isDarwin to avoid eagerly picking up ios wheels

### DIFF
--- a/lib/pypa.nix
+++ b/lib/pypa.nix
@@ -336,7 +336,7 @@ lib.fix (self: {
         arch = elemAt m 2;
       in
       assert m != null;
-      platform.isDarwin
+      platform.isiOS
       && arch == platform.darwinArch
       && compareVersions platform.darwinSdkVersion "${major}.${minor}" >= 0
     else if hasPrefix "android" platformTag then


### PR DESCRIPTION
Fixes an issue where if ios wheels appear first then they are used instead of macos wheels