### PR TITLE
templates: ensure flake inputs are consistent

### DIFF
--- a/templates/requirements-txt/flake.nix
+++ b/templates/requirements-txt/flake.nix
@@ -1,9 +1,9 @@
 {
   description = "Construct development shell from requirements.txt";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
+  inputs.pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs =
     { nixpkgs, pyproject-nix, ... }:


### PR DESCRIPTION
I noticed that the templates (and, in fact, most flakes in this repository, with the requirements-txt template being one exception) use `nixos-unstable` instead of `nixpkgs-unstable`.

From what I've read, `nixpkgs-*` is generally recommended for non-NixOS configuration/project flakes, while `nixos-*` is intended for NixOS system configurations.

This PR only updates the templates to use `nixpkgs-unstable`.

I'm still fairly new to the Nix ecosystem, so if I've misunderstood anything or there's a reason for the current choice, I'd really appreciate any feedback.

@adisbladis would you prefer that I also update the other flakes in this repository? If so, would you prefer that I include those changes in this PR, or would separate PR(s) be better?
